### PR TITLE
proteus : Manage rec_names from nested O2M returns in on_changes

### DIFF
--- a/proteus/__init__.py
+++ b/proteus/__init__.py
@@ -643,6 +643,8 @@ class Model(object):
             self._default_get()
 
         for field_name, value in kwargs.iteritems():
+            if field_name.endswith('.rec_name'):
+                continue
             definition = self._fields[field_name]
             if definition['type'] in ('one2many', 'many2many'):
                 relation = Model.get(definition['relation'])
@@ -661,6 +663,8 @@ class Model(object):
                     if isinstance(value, (int, long)):
                         relation = Model.get(definition['relation'])
                         value = relation(value)
+                        if field_name + '.rec_name' in kwargs:
+                            value.rec_name = kwargs[field_name + '.rec_name']
                 setattr(self, field_name, value)
     __init__.__doc__ = object.__init__.__doc__
 


### PR DESCRIPTION
The server may return something like :

  `{'myO2M': [('add', [{'my_field': 1, 'my_field.rec_name': 'foo'}])]}`

Which is currently not handled by proteus (causes a crash)