### PR TITLE
Instantiate O2M Function fields

### DIFF
--- a/proteus/__init__.py
+++ b/proteus/__init__.py
@@ -274,7 +274,10 @@ class One2ManyDescriptor(FieldDescriptor):
                 ctx.update(decoder.decode(self.definition.get('context')))
             config = Relation._config
             with config.reset_context(), config.set_context(ctx):
-                value = ModelList(self.definition, (Relation(id)
+                # JCA : Instantiate function O2M, which are read as dicts
+                # rather than ids
+                value = ModelList(self.definition, (
+                        Relation(**id) if isinstance(id, dict) else Relation(id)
                         for id in value or []), instance, self.name)
             instance._values[self.name] = value
         return value
@@ -671,7 +674,7 @@ class Model(object):
             self._default_get()
 
         for field_name, value in kwargs.items():
-            if field_name.endswith('.rec_name'):
+            if field_name.endswith('.'):
                 continue
             definition = self._fields[field_name]
             if definition['type'] in ('one2many', 'many2many'):


### PR DESCRIPTION
Currently O2M Function fields cannot be properly used in proteus,
because it assumes a read O2M field to always be an id.

Supposedly it is a valid use, so if the read values are a dict,
we actually instantiate it on the fly